### PR TITLE
Fixed an issue where images in cart product description would 404. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,20 @@
 # Changelog
 
-## 2.0.0
-
-### Major changes
-- Astro has been upgraded to v5.0
-
-#### What should I do on my fork?
-- Upgrade Astro and its dependencies
-  - Run `npx @astrojs/upgrade` in your terminal
-  - At the yellow warning, choose “Yes” to continue
-- Ensure that the other packages you may have added are up-to-date and compatible with Astro v5
-- Please refer to the [official Upgrade to v5 guide](https://docs.astro.build/en/guides/upgrade-to/v5/) if you run into any issues.
-
+## 0.2.2
 ### Minor changes
-- Added CHANGELOG.md to keep track of patch changes and setup instructions
+- Fixed an issue where images in cart product description would 404. This was caused by the Product component sending the whole image object instead of image.src to the cart <img> element.
+```diff
+- <Product as="span" id={product.id} image={image} >
++ <Product as="span" id={product.id} image={image.src} >
+```
+
+## 0.2.1
+Beta version
+### Major changes
+- Added documentation
+- Project is now using local images for products rather than remote
+
 
 ## 0.1.0
-### Added
-- Initial release of Beginner-Astro-v4-LESS template
+- Initial release of alpha version
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "advanced-astro-snipcart",
   "type": "module",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",

--- a/src/components/Snipcart/ProductCard.astro
+++ b/src/components/Snipcart/ProductCard.astro
@@ -33,7 +33,7 @@ const priceInCart = discountedPrice ? discountedPrice : price;
 					<Price currency={currency} price={price} discountedPrice={discountedPrice} />
 				</div>
 				<!-- Buy buton -->
-				<Product as="span" id={product.id} name={name} url=`/products/${product.id}` price={priceInCart} description={description} image={image}>
+				<Product as="span" id={product.id} name={name} url=`/products/${product.id}` price={priceInCart} description={description} image={image.src}>
 					<button class="cs-buy" aria-label={`Add ${name} to cart`}>
 						<Icon name="mdi--basket-plus" class="cs-basket" aria-hidden="true" />
 						<!-- <img class="cs-basket" src="https://csimg.nyc3.cdn.digitaloceanspaces.com/Images/Icons/ecomm-bag-icon.svg" alt="buy" height="24" width="24" loading="lazy" decoding="async" /> -->

--- a/src/components/Snipcart/QuantitySelector.astro
+++ b/src/components/Snipcart/QuantitySelector.astro
@@ -2,7 +2,6 @@
 import { Product } from "@lloydjatkinson/astro-snipcart/astro";
 const { product } = Astro.props;
 const { name, description, price, discountedPrice, discountPercent, currency, image, categories, relatedProductIds, quantity = 1 } = product.data;
-
 // We need to chck which price to pass to the Product component
 const priceInCart = discountedPrice ? discountedPrice : price
 ---
@@ -22,7 +21,7 @@ const priceInCart = discountedPrice ? discountedPrice : price
 	</div>
 </div>
 
-<Product as="span" id={product.id} name={name} url=`/products/${product.id}` price={priceInCart} description={description} image={image} quantity={quantity}>
+<Product as="span" id={product.id} name={name} url=`/products/${product.id}` price={priceInCart} description={description} image={image.src} quantity={quantity}>
 	<button class="cs-button-solid cs-button-buy" aria-label={`Add ${name} to cart`}> Add to cart </button>
 </Product>
 

--- a/src/pages/products/[...product].astro
+++ b/src/pages/products/[...product].astro
@@ -3,14 +3,6 @@ import { getCollection, render } from "astro:content";
 
 import BaseLayout from "@layouts/BaseLayout.astro";
 import ProductLayout from "@layouts/ProductLayout.astro";
-import CTA from "@components/CTA.astro";
-import Landing from "@components/Landing.astro";
-
-// Optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
-import {getOptimizedImage} from "@js/utils"
-import landingImage from "@assets/images/landing-products.jpg" // <-- THE PATH TO THE ASSET YOU WANT TO PRELOAD - The asset must live in src
-import type { InferGetStaticPropsType } from "astro";
-const optimizedImage = await getOptimizedImage(landingImage)
 
 export async function getStaticPaths() {
     const products = await getCollection("products");


### PR DESCRIPTION
 This was caused by the Product component sending the whole image object instead of image.src to the cart <img> element.
```diff
- <Product as="span" id={product.id} image={image} >
+ <Product as="span" id={product.id} image={image.src} >
```
