### PR TITLE
Fix - make snipcart accessible

### DIFF
--- a/src/components/Snipcart/CartDisplay.astro
+++ b/src/components/Snipcart/CartDisplay.astro
@@ -1,13 +1,14 @@
 ---
-import { Icon } from "astro-icon/components";
+/**
+ * * You may be getting `Cannot find name 'Snipcart'.` errors in your terminal. I think it's because the Snipcart API is not directly exposed via the Snipcart CDN, but via the Astro integration
+ * * it works nonetheless :)
+**/
 import { CartCheckout, CartItemsCount } from "@lloydjatkinson/astro-snipcart/astro";
 ---
 
 <div class="cs-cart">
 	<CartCheckout>
 		<button class="cs-button-solid snipcart-checkout-button" title="View Cart">
-			<!-- /* Use the Icon component if you want to change the icon */ -->
-			<!-- <Icon name="mdi--cart" /> -->
 			<svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"
 				><path
 					fill-rule="evenodd"
@@ -16,14 +17,18 @@ import { CartCheckout, CartItemsCount } from "@lloydjatkinson/astro-snipcart/ast
 					fill="currentColor"></path></svg
 			>
 			<CartItemsCount />
+			<div class="cs-hidden lg:cs-flex">
+				<kbd>Alt</kbd> + <kbd>C</kbd>
+			</div>
 		</button>
 	</CartCheckout>
 </div>
 
 <script>
-	// This script will ensure that the cart gets toggled back on when the checkout button is clicked (edge case for when the sign in modal is already opened)
+	// Ensures that the cart gets toggled back on when the checkout button is clicked (edge case for when the sign in modal is already opened)
 	document.addEventListener("snipcart.ready", () => {
 		const cartButtons = document.querySelectorAll(".snipcart-checkout-button");
+		if (cartButtons.length === 0) return;
 		cartButtons.forEach((button) => {
 			button.addEventListener("click", () => {
 				Snipcart.api.theme.cart.close();

--- a/src/components/Snipcart/ProductCard.astro
+++ b/src/components/Snipcart/ProductCard.astro
@@ -1,5 +1,5 @@
 ---
-import { Image, Picture } from "astro:assets";
+import { Picture } from "astro:assets";
 import { Product } from "@lloydjatkinson/astro-snipcart/astro";
 import Price from "./Price.astro";
 import { Icon } from "astro-icon/components";
@@ -32,11 +32,10 @@ const priceInCart = discountedPrice ? discountedPrice : price;
 					<!-- if there's no discount, use this: <Price currency={currency} price={ price } /> -->
 					<Price currency={currency} price={price} discountedPrice={discountedPrice} />
 				</div>
-				<!-- Buy buton -->
+				<!-- Buy buton - the .snipcart-checkout class will ensure the cart open on click-->
 				<Product as="span" id={product.id} name={name} url=`/products/${product.id}` price={priceInCart} description={description} image={image.src}>
-					<button class="cs-buy" aria-label={`Add ${name} to cart`}>
+					<button class="cs-buy snipcart-checkout" aria-label={`Add ${name} to cart`}>
 						<Icon name="mdi--basket-plus" class="cs-basket" aria-hidden="true" />
-						<!-- <img class="cs-basket" src="https://csimg.nyc3.cdn.digitaloceanspaces.com/Images/Icons/ecomm-bag-icon.svg" alt="buy" height="24" width="24" loading="lazy" decoding="async" /> -->
 					</button>
 				</Product>
 			</div>

--- a/src/js/snipcart-accessibility.js
+++ b/src/js/snipcart-accessibility.js
@@ -1,0 +1,200 @@
+// Constants
+const MODAL_RENDER_DELAY = 100;
+const ANNOUNCEMENT_DURATION = 1000;
+const SELECTORS = {
+  CART_MODAL: ".snipcart-layout__content",
+  SIGN_IN_MODAL: ".snipcart-signin",
+  MODAL_CONTAINER: ".snipcart-modal__container",
+  MODAL: ".snipcart-modal",
+  CLOSE_BUTTON: ".snipcart-cart__secondary-header button",
+  SIGN_IN_BUTTONS: ".snipcart-sign-in-button",
+  CHECKOUT_FORM: ".snipcart-form",
+  SITE_LOGO: "#cs-navigation a"
+};
+
+// Helper functions
+function getElement(selector) {
+  return document.querySelector(selector);
+}
+
+function getAllElements(selector) {
+  return document.querySelectorAll(selector);
+}
+
+function getFocusableElements(container) {
+  return container.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+}
+
+// Focus management
+function setFocusOnFirstElement(containerSelector) {
+  const container = getElement(containerSelector);
+  if (!container) return;
+  
+  const focusableElements = getFocusableElements(container);
+  if (focusableElements.length > 0) {
+    focusableElements[0].focus();
+  }
+}
+
+// ARIA attribute management
+function setAriaAttributes(modal) {
+  if (!modal) return;
+  
+  // Set dialog role and properties
+  modal.setAttribute("role", "dialog");
+  modal.setAttribute("aria-modal", "true");
+  modal.setAttribute("aria-labelledby", "cart-title");
+  
+  // Set title ID for proper labeling
+  const title = modal.querySelector("h1");
+  if (title && !title.id) {
+    title.id = "cart-title";
+  }
+  
+  // Set aria-live on container
+  const modalContainer = getElement(SELECTORS.MODAL_CONTAINER);
+  if (modalContainer && !modalContainer.hasAttribute("aria-live")) {
+    modalContainer.setAttribute("aria-live", "polite");
+  }
+  
+  // Set aria-label on close button
+  const closeButton = getElement(SELECTORS.CLOSE_BUTTON);
+  if (closeButton && !closeButton.hasAttribute("aria-label")) {
+    closeButton.setAttribute("aria-label", "Close cart");
+  }
+}
+
+// Keyboard navigation
+function trapFocus(modal) {
+  if (!modal) return;
+  
+  const focusableElements = getFocusableElements(modal);
+  if (focusableElements.length === 0) return;
+  
+  const firstElement = focusableElements[0];
+  const lastElement = focusableElements[focusableElements.length - 1];
+  
+  modal.addEventListener("keydown", (e) => {
+    if (e.key === "Tab") {
+      // Handle focus trapping
+      if (e.shiftKey && document.activeElement === firstElement) {
+        e.preventDefault();
+        lastElement.focus();
+      } else if (!e.shiftKey && document.activeElement === lastElement) {
+        e.preventDefault();
+        firstElement.focus();
+      }
+    } else if (e.key === "Escape") {
+      // Close modal and return focus
+      Snipcart.api.theme.cart.close();
+      const siteLogo = getElement(SELECTORS.SITE_LOGO);
+      if (siteLogo) siteLogo.focus();
+    }
+  });
+}
+
+// Main functionality
+function setupCartAccessibility() {
+  setTimeout(() => {
+    const cartModal = getElement(SELECTORS.CART_MODAL);
+    if (!cartModal) return;
+    
+    setFocusOnFirstElement(SELECTORS.CART_MODAL);
+    setAriaAttributes(cartModal);
+    trapFocus(cartModal);
+  }, MODAL_RENDER_DELAY);
+}
+
+function setupSignInAccessibility() {
+  setTimeout(() => {
+    const signInModal = getElement(SELECTORS.MODAL);
+    if (!signInModal) return;
+    
+    setFocusOnFirstElement(SELECTORS.SIGN_IN_MODAL);
+    setAriaAttributes(signInModal);
+    trapFocus(signInModal);
+  }, MODAL_RENDER_DELAY);
+}
+
+// Event handlers
+function handleSignInEvent(event) {
+  if (event.type === "click" || event.key === "Enter" || event.key === " ") {
+    setupSignInAccessibility();
+  }
+}
+
+// Create and set up live region for screen reader announcements
+function createLiveRegion() {
+  // Check if live region already exists
+  if (getElement('#cart-announcer')) return getElement('#cart-announcer');
+  
+  const liveRegion = document.createElement('div');
+  liveRegion.id = 'cart-announcer';
+  liveRegion.setAttribute('aria-live', 'polite');
+  liveRegion.setAttribute('aria-atomic', 'true');
+  liveRegion.setAttribute('class', 'sr-only'); // Visually hidden but available to screen readers
+  liveRegion.style.cssText = 'position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;';
+  document.body.appendChild(liveRegion);
+  
+  return liveRegion;
+}
+
+// Announce messages to screen readers
+function announce(message) {
+  const liveRegion = createLiveRegion();
+  liveRegion.textContent = message;
+  setTimeout(() => { liveRegion.textContent = ''; }, ANNOUNCEMENT_DURATION);
+}
+
+// Announce cart changes
+function setupCartAnnouncements() {
+  Snipcart.events.on('item.added', (item) => {
+    announce(`${item.name} added to cart. Your cart now contains ${Snipcart.store.getState().cart.items.count} items.`);
+  });
+  
+  Snipcart.events.on('item.removed', (item) => {
+    announce(`${item.name} removed from cart.`);
+  });
+  
+  Snipcart.events.on('item.updated', (item) => {
+    announce(`${item.name} quantity updated to ${item.quantity}.`);
+  });
+  
+  Snipcart.events.on('cart.ready', () => {
+    const itemCount = Snipcart.store.getState().cart.items.count;
+    if (itemCount > 0) {
+      announce(`Cart opened. You have ${itemCount} items in your cart.`);
+    } else {
+      announce('Cart opened. Your cart is empty.');
+    }
+  });
+}
+
+// Add keyboard shortcuts
+function setupKeyboardShortcuts() {
+  document.addEventListener('keydown', (e) => {
+    // Alt+C to open cart
+    if (e.altKey && e.key === 'c') {
+      e.preventDefault();
+      Snipcart.api.theme.cart.open();
+	  setupCartAccessibility();
+      announce('Cart opened via keyboard shortcut');
+    }
+  });
+}
+
+// Initialize all accessibility features
+function initAccessibility() {
+  Snipcart.events.on("summary.checkout_clicked", setupCartAccessibility);
+  
+  getAllElements(SELECTORS.SIGN_IN_BUTTONS).forEach((button) => {
+    button.addEventListener("click", handleSignInEvent);
+    button.addEventListener("keydown", handleSignInEvent);
+  });
+  
+  setupCartAnnouncements();
+  setupKeyboardShortcuts();
+}
+
+// Initialize when Snipcart is ready
+document.addEventListener("snipcart.ready", initAccessibility);

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -69,6 +69,7 @@ const { description, title, preloadedImage } = Astro.props;
     
     <!-- Sitewide Scripts -->
     <script src="../js/nav.js"></script>
+    <script src="../js/snipcart-accessibility.js"></script>
   </head>
 
   <body>

--- a/src/styles/root.less
+++ b/src/styles/root.less
@@ -208,12 +208,42 @@ ul {
 	z-index: -1111111;
 }
 
+.sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border-width: 0;
+}
+
+*:focus,
 *:focus-visible {
 	outline-color: var(--primary);
 	outline-style: solid;
 	outline-offset: 0.25rem;
 	outline-width: 0.25rem;
 }
+
+kbd {
+	background-color: #eee;
+	border-radius: 3px;
+	border: 1px solid #b4b4b4;
+	box-shadow:
+	  0 1px 1px rgba(0, 0, 0, 0.2),
+	  0 2px 0 0 rgba(255, 255, 255, 0.7) inset;
+	color: #333;
+	display: inline-block;
+	font-size: 0.85em;
+	font-weight: 700;
+	line-height: 1;
+	padding: 2px 4px;
+	white-space: nowrap;
+  }
+  
 
 /* Scale full website with the viewport width */
 @media only screen and (min-width: 2000px) {


### PR DESCRIPTION
Out of the box, Snipcart suffers accessibility issues. This PR aims to address these by:
 - making cart and signin modals accessible by keyboard navigation
 - auto focusing elements in the modals when opened
 - setting focus trap in modals
 - setting keyboard navigation in modals
 - adding a keyboard shortcult `Alt + C` to open the cart
 - adding relevant aria-* attributes
 
 Closes #3 